### PR TITLE
Adding support for setting tmux window titles

### DIFF
--- a/zsh-window-title.zsh
+++ b/zsh-window-title.zsh
@@ -92,13 +92,25 @@ __zsh-window-title:init() {
 	__zsh-window-title:add-hooks
 }
 
+__zsh-window-title:set-title() {
+	case $TERM in
+		screen*|\
+		tmux*)
+			'builtin' 'echo' -ne "\033k$1\033\\"
+			;;
+		*)
+			'builtin' 'echo' -ne "\033]0;$1\007"
+			;;
+	esac
+}
+
 __zsh-window-title:precmd() {
 	'builtin' 'emulate' -LR zsh
 	__zsh-window-title:debugger
 
 	local title=$(print -P "%$ZSH_WINDOW_TITLE_DIRECTORY_DEPTH~")
 
-	'builtin' 'echo' -ne "\033]0;$title\007"
+    __zsh-window-title:set-title $title
 }
 
 __zsh-window-title:preexec() {
@@ -107,7 +119,7 @@ __zsh-window-title:preexec() {
 
 	local title=$(print -P "%$ZSH_WINDOW_TITLE_DIRECTORY_DEPTH~ - ${1[(w)1]}")
 
-	'builtin' 'echo' -ne "\033]0;$title\007"
+    __zsh-window-title:set-title $title
 }
 
 zwt() {


### PR DESCRIPTION
This PR adds support for updating tmux window titles as described in #4.

Steps to verify the functionaity:

1. Install tmux.
2. Create tmux configuration file and allow applications to set tmux window titles.
```
echo "set -g allow-rename on" >> ~/.tmux.conf
```
3. Start tmux.
```
tmux new-session
```
4. Start zsh if it isn't the default shell.
5. Tmux window title should be dynamically updated based on current path and running command (refer screenshot).
![image](https://user-images.githubusercontent.com/29375430/173185995-cc5fedc4-af27-4c6f-8b3e-afcc8bbde337.png)
6. Exit shell to close tmux.
